### PR TITLE
`ExecuteCommandPacketIn`: implement `as_player`

### DIFF
--- a/src/main/java/com/denizenscript/depenizen/bungee/packets/in/ExecuteCommandPacketIn.java
+++ b/src/main/java/com/denizenscript/depenizen/bungee/packets/in/ExecuteCommandPacketIn.java
@@ -4,6 +4,9 @@ import com.denizenscript.depenizen.bungee.DepenizenConnection;
 import com.denizenscript.depenizen.bungee.PacketIn;
 import io.netty.buffer.ByteBuf;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+
+import java.util.UUID;
 
 public class ExecuteCommandPacketIn extends PacketIn {
 
@@ -18,6 +21,14 @@ public class ExecuteCommandPacketIn extends PacketIn {
         if (command == null) {
             return;
         }
-        ProxyServer.getInstance().getPluginManager().dispatchCommand(ProxyServer.getInstance().getConsole(), command);
+        if (data.readableBytes() < 16) {
+            ProxyServer.getInstance().getPluginManager().dispatchCommand(ProxyServer.getInstance().getConsole(), command);
+            return;
+        }
+        UUID executingPlayerUUID = new UUID(data.readLong(), data.readLong());
+        ProxiedPlayer executingPlayer = ProxyServer.getInstance().getPlayer(executingPlayerUUID);
+        if (executingPlayer != null) {
+            ProxyServer.getInstance().getPluginManager().dispatchCommand(executingPlayer, command);
+        }
     }
 }


### PR DESCRIPTION
## Changes

- Support executing as player in `ExecuteCommandPacketIn`, see https://github.com/DenizenScript/Depenizen/pull/406.